### PR TITLE
feat(serde): Use serde and bitcode to store structs as blobs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,14 @@ repository = "https://github.com/mrivnak/pond"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bitcode = { version = "0.6.0", default-features = false, features = ["serde"] }
 chrono = { version = "0.4.38", features = ["serde"] }
-rusqlite = { version = "0.31.0", features = ["bundled"] }
+rusqlite = { version = "0.31.0", features = ["blob", "bundled"] }
+serde = "1.0.202"
 
 [dev-dependencies]
+bitcode = { version = "0.6.0", features = ["serde"] }
 rand = "0.8.5"
-uuid = { version = "1.8.0", features = ["v4"] }
+serde = { version = "1.0.202", features = ["derive"] }
+uuid = { version = "1.8.0", features = ["v4", "serde"] }
 


### PR DESCRIPTION
Closes #20
Avoids having to manually (de)serialize structs when storing. Opted to use serde rather than a derive macro to generate custom db tables since access to specific fields is not necessary and that would add a lot of complexity.